### PR TITLE
docs: add Zulip community link to README (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,3 +491,9 @@ aiobs is an open, extensible Python SDK supporting AI observability and agentic 
 
 👉 [https://neuralis-in.github.io/shepherd/](https://neuralis-in.github.io/shepherd/)  
 👉 [https://github.com/neuralis-in/aiobs](https://github.com/neuralis-in/aiobs)
+
+## Community & Support
+
+Join the Zulip community for discussions, help, and feature requests:
+
+👉[https://aiobs.zulipchat.com/](Organisation URL: https://aiobs.zulipchat.com/)


### PR DESCRIPTION
This PR adds the official Zulip community link to the README to make it easier for contributors and users to join discussions and get support.


