### PR TITLE
feat: Added SQLQueryValidator Eval

### DIFF
--- a/aiobs/evals/__init__.py
+++ b/aiobs/evals/__init__.py
@@ -52,6 +52,7 @@ from .models import (
     PIIDetectionConfig,
     PIIType,
     HallucinationDetectionConfig,
+    SQLQueryValidatorConfig,
 )
 
 # Correctness evaluators
@@ -60,6 +61,7 @@ from .correctness import (
     SchemaAssertion,
     GroundTruthEval,
     HallucinationDetectionEval,
+    SQLQueryValidator,
 )
 
 # Reliability evaluators
@@ -90,11 +92,13 @@ __all__ = [
     "PIIDetectionConfig",
     "PIIType",
     "HallucinationDetectionConfig",
+    "SQLQueryValidatorConfig",
     # Correctness evaluators
     "RegexAssertion",
     "SchemaAssertion",
     "GroundTruthEval",
     "HallucinationDetectionEval",
+    "SQLQueryValidator",
     # Reliability evaluators
     "LatencyConsistencyEval",
     # Safety evaluators

--- a/aiobs/evals/correctness/__init__.py
+++ b/aiobs/evals/correctness/__init__.py
@@ -6,11 +6,13 @@ from .regex_assertion import RegexAssertion
 from .schema_assertion import SchemaAssertion
 from .ground_truth import GroundTruthEval
 from .hallucination_detection import HallucinationDetectionEval
+from .sql_query_validator import SQLQueryValidator
 
 __all__ = [
     "RegexAssertion",
     "SchemaAssertion",
     "GroundTruthEval",
     "HallucinationDetectionEval",
+    "SQLQueryValidator",
 ]
 

--- a/aiobs/evals/correctness/sql_query_validator.py
+++ b/aiobs/evals/correctness/sql_query_validator.py
@@ -1,0 +1,176 @@
+"""SQL query validation evaluator."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Type
+
+from ..base import BaseEval
+from ..models import (
+    EvalInput,
+    EvalResult,
+    EvalStatus,
+    SQLQueryValidatorConfig,
+    AssertionDetail,
+)
+
+
+class SQLQueryValidator(BaseEval):
+    """Evaluator that validates SQL query syntax.
+    
+    This evaluator checks if the model output is a valid SQL query
+    using sqlglot for parsing and validation. Supports multiple SQL
+    dialects including PostgreSQL, MySQL, SQLite, and more.
+    
+    Example:
+        evaluator = SQLQueryValidator()
+        
+        result = evaluator.evaluate(
+            EvalInput(
+                user_input="Get all users",
+                model_output="SELECT * FROM users"
+            )
+        )
+        assert result.passed
+        
+        # With specific dialect
+        config = SQLQueryValidatorConfig(dialect="postgres")
+        evaluator = SQLQueryValidator(config)
+        
+        result = evaluator.evaluate(
+            EvalInput(
+                user_input="Get users with limit",
+                model_output="SELECT * FROM users LIMIT 10"
+            )
+        )
+        assert result.passed
+    """
+    
+    name: str = "sql_query_validator"
+    description: str = "Validates that output is a valid SQL query"
+    config_class: Type[SQLQueryValidatorConfig] = SQLQueryValidatorConfig
+    
+    _sqlglot_available: Optional[bool] = None
+    
+    def __init__(self, config: Optional[SQLQueryValidatorConfig] = None) -> None:
+        """Initialize the SQL query validator.
+        
+        Args:
+            config: Configuration for SQL validation.
+        """
+        super().__init__(config)
+        self.config: SQLQueryValidatorConfig = self.config
+    
+    @classmethod
+    def is_available(cls) -> bool:
+        """Check if sqlglot is installed.
+        
+        Returns:
+            True if sqlglot is available, False otherwise.
+        """
+        if cls._sqlglot_available is None:
+            try:
+                import sqlglot  # noqa: F401
+                cls._sqlglot_available = True
+            except ImportError:
+                cls._sqlglot_available = False
+        return cls._sqlglot_available
+    
+    def evaluate(self, eval_input: EvalInput, **kwargs: Any) -> EvalResult:
+        """Evaluate if model output is valid SQL.
+        
+        Args:
+            eval_input: Input containing model_output to validate.
+            **kwargs: Additional arguments (unused).
+            
+        Returns:
+            EvalResult indicating pass/fail with details about SQL validity.
+            
+        Raises:
+            ImportError: If sqlglot is not installed.
+        """
+        if not self.is_available():
+            raise ImportError(
+                "sqlglot is required for SQLQueryValidator. "
+                "Install it with: pip install 'aiobs[sql]'"
+            )
+        
+        import sqlglot
+        from sqlglot.errors import ParseError
+        
+        output = eval_input.model_output.strip()
+        assertions: List[AssertionDetail] = []
+        
+        # Attempt to parse the SQL query
+        try:
+            # Parse with specified dialect if provided
+            parsed = sqlglot.parse_one(output, dialect=self.config.dialect)
+            
+            # Additional validation: ensure something was parsed
+            if parsed is None:
+                assertions.append(AssertionDetail(
+                    name="sql_parse",
+                    passed=False,
+                    expected="Valid SQL query",
+                    actual=output[:100] + "..." if len(output) > 100 else output,
+                    message="Parser returned None - possibly empty or invalid SQL",
+                ))
+                return EvalResult(
+                    status=EvalStatus.FAILED,
+                    score=0.0,
+                    eval_name=self.eval_name,
+                    message="Invalid SQL: Parser returned None",
+                    assertions=assertions,
+                )
+            
+            # Successfully parsed
+            dialect_info = f" (dialect: {self.config.dialect})" if self.config.dialect else ""
+            assertions.append(AssertionDetail(
+                name="sql_parse",
+                passed=True,
+                expected="Valid SQL query",
+                actual="Parsed successfully",
+                message=f"Output is valid SQL{dialect_info}",
+            ))
+            
+            return EvalResult(
+                status=EvalStatus.PASSED,
+                score=1.0,
+                eval_name=self.eval_name,
+                message=f"Valid SQL query{dialect_info}",
+                assertions=assertions,
+            )
+            
+        except ParseError as e:
+            # SQL parsing failed
+            error_msg = str(e)
+            assertions.append(AssertionDetail(
+                name="sql_parse",
+                passed=False,
+                expected="Valid SQL query",
+                actual=output[:100] + "..." if len(output) > 100 else output,
+                message=error_msg,
+            ))
+            return EvalResult(
+                status=EvalStatus.FAILED,
+                score=0.0,
+                eval_name=self.eval_name,
+                message=f"Invalid SQL: {error_msg}",
+                assertions=assertions,
+            )
+        except Exception as e:
+            # Unexpected error during parsing
+            error_msg = f"Unexpected error: {type(e).__name__}: {str(e)}"
+            assertions.append(AssertionDetail(
+                name="sql_parse",
+                passed=False,
+                expected="Valid SQL query",
+                actual=output[:100] + "..." if len(output) > 100 else output,
+                message=error_msg,
+            ))
+            return EvalResult(
+                status=EvalStatus.FAILED,
+                score=0.0,
+                eval_name=self.eval_name,
+                message=error_msg,
+                assertions=assertions,
+            )

--- a/aiobs/evals/models/__init__.py
+++ b/aiobs/evals/models/__init__.py
@@ -14,6 +14,7 @@ from .configs import (
     PIIDetectionConfig,
     PIIType,
     HallucinationDetectionConfig,
+    SQLQueryValidatorConfig,
 )
 
 __all__ = [
@@ -32,5 +33,6 @@ __all__ = [
     "PIIDetectionConfig",
     "PIIType",
     "HallucinationDetectionConfig",
+    "SQLQueryValidatorConfig",
 ]
 

--- a/aiobs/evals/models/configs.py
+++ b/aiobs/evals/models/configs.py
@@ -249,3 +249,18 @@ class HallucinationDetectionConfig(BaseEvalConfig):
         description="Maximum number of claims to extract and evaluate"
     )
 
+
+class SQLQueryValidatorConfig(BaseEvalConfig):
+    """Configuration for SQL query validation evaluator.
+    
+    Validates that model output is a syntactically correct SQL query
+    using sqlglot. Supports multiple SQL dialects for dialect-specific
+    validation.
+    """
+    
+    dialect: Optional[str] = Field(
+        default=None,
+        description="SQL dialect for parsing (postgres, mysql, sqlite, etc.). "
+                    "If None, uses default sqlglot parsing."
+    )
+

--- a/example/evals/sql_query_validator_example.py
+++ b/example/evals/sql_query_validator_example.py
@@ -1,0 +1,119 @@
+"""Minimal example: SQLQueryValidator evaluator.
+
+Validates that model output is a valid SQL query using sqlglot.
+
+Requirements:
+    pip install 'aiobs[sql]'
+"""
+
+from aiobs.evals import EvalInput, SQLQueryValidator, SQLQueryValidatorConfig
+
+# --- Example 1: Basic SQL validation ---
+print("--- Example 1: Basic SQL Validation ---")
+
+evaluator = SQLQueryValidator()
+
+# Test with valid SQL
+valid_input = EvalInput(
+    user_input="Get all users from the database",
+    model_output="SELECT * FROM users",
+)
+
+result = evaluator(valid_input)
+print(f"Valid SQL - Status: {result.status.value}, Score: {result.score}")
+print(f"Message: {result.message}\n")
+
+# Test with invalid SQL
+invalid_input = EvalInput(
+    user_input="Get all users",
+    model_output="SELECT FROM WHERE",  # Invalid SQL structure
+)
+
+result = evaluator(invalid_input)
+print(f"Invalid SQL - Status: {result.status.value}, Score: {result.score}")
+print(f"Message: {result.message}\n")
+
+
+# --- Example 2: Dialect-specific validation ---
+print("--- Example 2: PostgreSQL Dialect ---")
+
+postgres_config = SQLQueryValidatorConfig(dialect="postgres")
+pg_evaluator = SQLQueryValidator(postgres_config)
+
+# PostgreSQL-specific query
+pg_input = EvalInput(
+    user_input="Get first 10 users",
+    model_output="SELECT * FROM users LIMIT 10",
+)
+
+result = pg_evaluator(pg_input)
+print(f"PostgreSQL Query - Status: {result.status.value}")
+print(f"Message: {result.message}\n")
+
+
+# --- Example 3: Complex query validation ---
+print("--- Example 3: Complex Query Validation ---")
+
+complex_input = EvalInput(
+    user_input="Get users who registered in the last 30 days with their order counts",
+    model_output="""
+        SELECT 
+            u.id,
+            u.name,
+            u.email,
+            COUNT(o.id) as order_count
+        FROM users u
+        LEFT JOIN orders o ON u.id = o.user_id
+        WHERE u.created_at >= NOW() - INTERVAL '30 days'
+        GROUP BY u.id, u.name, u.email
+        ORDER BY order_count DESC
+    """,
+)
+
+result = evaluator(complex_input)
+print(f"Complex Query - Status: {result.status.value}")
+print(f"Message: {result.message}\n")
+
+
+# --- Example 4: Dialect-Specific Query ---
+print("--- Example 4: PostgreSQL-Specific Query ---")
+
+# PostgreSQL-specific syntax with INTERVAL
+postgres_config = SQLQueryValidatorConfig(dialect="postgres")
+postgres_evaluator = SQLQueryValidator(postgres_config)
+
+postgres_specific_input = EvalInput(
+    user_input="Get users who registered in the last week",
+    model_output="SELECT * FROM users WHERE created_at > NOW() - INTERVAL '7 days'",
+)
+
+result = postgres_evaluator(postgres_specific_input)
+print(f"PostgreSQL-specific syntax: {result.status.value}")
+print(f"Message: {result.message}\n")
+
+# Try the same query without dialect
+generic_evaluator = SQLQueryValidator()
+result_generic = generic_evaluator(postgres_specific_input)
+print(f"Same query without dialect: {result_generic.status.value}")
+
+
+# --- Example 5: Validating LLM-Generated SQL ---
+print("\n--- Example 5: Validating LLM-Generated SQL ---")
+
+# Simulate an LLM that might generate invalid SQL
+test_cases = [
+    ("SELECT * FROM products WHERE", "Incomplete WHERE clause"),
+    ("UPDATE users SET status = 'active' WHERE id = 1", "Valid UPDATE statement"),
+    ("DELETE FROM orders WHERE order_date < '2023-01-01'", "Valid DELETE statement"),
+    ("INSERT INTO users (name, email) VALUES ('John', 'john@example.com')", "Valid INSERT statement"),
+]
+
+for sql_query, description in test_cases:
+    result = evaluator(EvalInput(
+        user_input="Execute query",
+        model_output=sql_query,
+    ))
+    status_symbol = "✓" if result.passed else "✗"
+    print(f"{status_symbol} {description}: {result.status.value}")
+    if result.failed and result.assertions:
+        print(f"   Error: {result.assertions[0].message[:80]}...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ openai = [
 gemini = [
   "google-genai>=1.0.0",
 ]
+sql = [
+  "sqlglot>=20.0.0",
+]
 example = [
   "python-dotenv>=1.0",
 ]


### PR DESCRIPTION
## Summary
Implements a deterministic evaluator that validates whether LLM output is a valid SQL query using sqlglot. This evaluator helps ensure that LLM-generated SQL queries are syntactically correct before execution.
Fixes #44 
## Changes

### Core Implementation
- **New Evaluator**: `aiobs/evals/correctness/sql_query_validator.py`
  - Validates SQL query syntax using `sqlglot.parse_one()`
  - Supports multiple SQL dialects (PostgreSQL, MySQL, SQLite, etc.)
  - Provides detailed error messages with line numbers on parse failures
  - Implements `is_available()` check for optional dependency

- **Configuration**: `aiobs/evals/models/configs.py`
  - Added `SQLQueryValidatorConfig` with `dialect` option
  - Allows dialect-specific validation (e.g., "postgres", "mysql")
  
 ### Dependencies
- **pyproject.toml**: Added optional dependency `sql = ["sqlglot>=20.0.0"]`
  
### Testing
- **13 unit tests** in `tests/test_evals.py`
- **Example file**: `example/evals/sql_query_validator_example.py`
