### PR TITLE
feat: Add S3Exporter for exporting observability data to Amazon S3

### DIFF
--- a/aiobs/exporters/__init__.py
+++ b/aiobs/exporters/__init__.py
@@ -5,10 +5,12 @@ to various destinations.
 
 Supported exporters:
     - GCSExporter: Export to Google Cloud Storage
+    - S3Exporter: Export to Amazon S3
     - CustomExporter: User-defined export logic via callback
     - CompositeExporter: Export to multiple destinations
 
 Example usage:
+    # Using GCSExporter
     from aiobs import observer
     from aiobs.exporters import GCSExporter
 
@@ -22,6 +24,31 @@ Example usage:
     # ... your agent code ...
     observer.end()
     observer.flush(exporter=exporter)
+
+    # Using S3Exporter
+    from aiobs.exporters import S3Exporter
+
+    s3_exporter = S3Exporter(
+        bucket="my-traces-bucket",
+        region="us-east-1",
+        prefix="shepherd/",
+    )
+    observer.flush(exporter=s3_exporter)
+
+    # Using CustomExporter
+    from aiobs.exporters import CustomExporter, ExportResult
+
+    def my_export_handler(data, options):
+        # Send to custom API, database, etc.
+        # (implementation depends on your needs)
+        return ExportResult(
+            success=True,
+            destination="custom://destination",
+            metadata={"custom": "metadata"},
+        )
+
+    custom_exporter = CustomExporter(handler=my_export_handler)
+    observer.flush(exporter=custom_exporter)
 """
 
 from .base import BaseExporter, ExportResult, ExportError
@@ -34,6 +61,7 @@ __all__ = [
     "ExportError",
     # Built-in exporters
     "GCSExporter",
+    "S3Exporter",
     "CustomExporter",
     "CompositeExporter",
 ]
@@ -44,5 +72,8 @@ def __getattr__(name: str):
     if name == "GCSExporter":
         from .gcs import GCSExporter
         return GCSExporter
+    if name == "S3Exporter":
+        from .s3 import S3Exporter
+        return S3Exporter
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/aiobs/exporters/s3.py
+++ b/aiobs/exporters/s3.py
@@ -1,0 +1,216 @@
+"""Amazon S3 exporter for aiobs observability data.
+
+Exports observability data to Amazon S3 buckets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Optional
+
+from .base import BaseExporter, ExportResult, ExportError
+from ..models import ObservabilityExport
+
+
+class S3Exporter(BaseExporter):
+    """Export observability data to Amazon S3.
+
+    Example usage:
+        from aiobs.exporters import S3Exporter
+
+        exporter = S3Exporter(
+            bucket="my-traces-bucket",
+            region="us-east-1",
+            prefix="shepherd/",
+        )
+        observer.flush(exporter=exporter)
+
+    Authentication:
+        The exporter uses AWS's default authentication chain:
+        1. AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
+        2. AWS credentials file (~/.aws/credentials)
+        3. IAM role credentials (when running on EC2/ECS/Lambda)
+        4. AWS_PROFILE environment variable for named profiles
+
+    Args:
+        bucket: The S3 bucket name (required).
+        region: AWS region name (e.g., "us-east-1"). Defaults to "us-east-1".
+        prefix: Path prefix within the bucket (e.g., "shepherd/"). Defaults to "".
+        aws_access_key_id: AWS access key ID. If not provided, uses default auth chain.
+        aws_secret_access_key: AWS secret access key. If not provided, uses default auth chain.
+        aws_session_token: AWS session token for temporary credentials.
+        filename_template: Template for the output filename. Supports placeholders:
+                          - {session_id}: First session ID
+                          - {timestamp}: Unix timestamp
+                          - {date}: Date in YYYY-MM-DD format
+                          Defaults to "{session_id}.json"
+        content_type: Content-Type for uploaded files. Defaults to "application/json".
+    """
+
+    name: str = "s3"
+
+    def __init__(
+        self,
+        bucket: str,
+        region: str = "us-east-1",
+        prefix: str = "",
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        filename_template: str = "{session_id}.json",
+        content_type: str = "application/json",
+    ) -> None:
+        self.bucket = bucket
+        self.region = region
+        self.prefix = prefix.rstrip("/") + "/" if prefix and not prefix.endswith("/") else prefix
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_session_token = aws_session_token
+        self.filename_template = filename_template
+        self.content_type = content_type
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        """Lazily initialize the S3 client."""
+        if self._client is None:
+            try:
+                import boto3
+            except ImportError as e:
+                raise ExportError(
+                    "boto3 is required for S3Exporter. "
+                    "Install it with: pip install boto3",
+                    cause=e,
+                )
+
+            client_kwargs = {"region_name": self.region}
+            
+            if self.aws_access_key_id and self.aws_secret_access_key:
+                client_kwargs["aws_access_key_id"] = self.aws_access_key_id
+                client_kwargs["aws_secret_access_key"] = self.aws_secret_access_key
+                if self.aws_session_token:
+                    client_kwargs["aws_session_token"] = self.aws_session_token
+            
+            self._client = boto3.client("s3", **client_kwargs)
+
+        return self._client
+
+    def _generate_filename(self, data: ObservabilityExport) -> str:
+        """Generate the filename from the template."""
+        session_id = "unknown"
+        if data.sessions:
+            session_id = data.sessions[0].id
+
+        timestamp = int(time.time())
+        date = time.strftime("%Y-%m-%d")
+
+        return self.filename_template.format(
+            session_id=session_id,
+            timestamp=timestamp,
+            date=date,
+        )
+
+    def export(self, data: ObservabilityExport, **kwargs: Any) -> ExportResult:
+        """Export observability data to S3.
+
+        Args:
+            data: The ObservabilityExport object to export.
+            **kwargs: Additional options:
+                - filename: Override the filename (ignores template).
+                - metadata: Dict of custom metadata to attach to the object.
+
+        Returns:
+            ExportResult with the S3 URI and export metadata.
+
+        Raises:
+            ExportError: If upload fails.
+        """
+        self.validate(data)
+
+        try:
+            client = self._get_client()
+
+            # Generate filename
+            filename = kwargs.get("filename") or self._generate_filename(data)
+            key = f"{self.prefix}{filename}"
+
+            # Serialize data
+            json_data = json.dumps(data.model_dump(), ensure_ascii=False, indent=2)
+            bytes_data = json_data.encode("utf-8")
+
+            # Prepare upload parameters
+            upload_kwargs = {
+                "Bucket": self.bucket,
+                "Key": key,
+                "Body": bytes_data,
+                "ContentType": self.content_type,
+            }
+
+            # Add custom metadata if provided
+            if metadata := kwargs.get("metadata"):
+                upload_kwargs["Metadata"] = {
+                    str(k): str(v) for k, v in metadata.items()
+                }
+
+            # Upload
+            client.put_object(**upload_kwargs)
+
+            s3_uri = f"s3://{self.bucket}/{key}"
+
+            return ExportResult(
+                success=True,
+                destination=s3_uri,
+                bytes_written=len(bytes_data),
+                metadata={
+                    "bucket": self.bucket,
+                    "key": key,
+                    "region": self.region,
+                    "content_type": self.content_type,
+                    "sessions_count": len(data.sessions),
+                    "events_count": len(data.events),
+                    "function_events_count": len(data.function_events),
+                },
+            )
+
+        except ExportError:
+            raise
+        except Exception as e:
+            raise ExportError(f"Failed to export to S3: {e}", cause=e)
+
+    @classmethod
+    def from_env(
+        cls,
+        bucket_env: str = "AIOBS_S3_BUCKET",
+        region_env: str = "AIOBS_S3_REGION",
+        prefix_env: str = "AIOBS_S3_PREFIX",
+        access_key_env: str = "AWS_ACCESS_KEY_ID",
+        secret_key_env: str = "AWS_SECRET_ACCESS_KEY",
+    ) -> "S3Exporter":
+        """Create an S3Exporter from environment variables.
+
+        Args:
+            bucket_env: Environment variable name for bucket.
+            region_env: Environment variable name for region.
+            prefix_env: Environment variable name for prefix.
+            access_key_env: Environment variable name for AWS access key ID.
+            secret_key_env: Environment variable name for AWS secret access key.
+
+        Returns:
+            Configured S3Exporter instance.
+
+        Raises:
+            ExportError: If required environment variables are missing.
+        """
+        bucket = os.getenv(bucket_env)
+        if not bucket:
+            raise ExportError(f"Environment variable {bucket_env} is required")
+
+        return cls(
+            bucket=bucket,
+            region=os.getenv(region_env, "us-east-1"),
+            prefix=os.getenv(prefix_env, ""),
+            aws_access_key_id=os.getenv(access_key_env),
+            aws_secret_access_key=os.getenv(secret_key_env),
+        )
+

--- a/aiobs/exporters/s3.py
+++ b/aiobs/exporters/s3.py
@@ -186,6 +186,7 @@ class S3Exporter(BaseExporter):
         prefix_env: str = "AIOBS_S3_PREFIX",
         access_key_env: str = "AWS_ACCESS_KEY_ID",
         secret_key_env: str = "AWS_SECRET_ACCESS_KEY",
+        session_token_env: str = "AWS_SESSION_TOKEN",
     ) -> "S3Exporter":
         """Create an S3Exporter from environment variables.
 
@@ -195,6 +196,7 @@ class S3Exporter(BaseExporter):
             prefix_env: Environment variable name for prefix.
             access_key_env: Environment variable name for AWS access key ID.
             secret_key_env: Environment variable name for AWS secret access key.
+            session_token_env: Environment variable name for AWS session token.
 
         Returns:
             Configured S3Exporter instance.
@@ -212,5 +214,8 @@ class S3Exporter(BaseExporter):
             prefix=os.getenv(prefix_env, ""),
             aws_access_key_id=os.getenv(access_key_env),
             aws_secret_access_key=os.getenv(secret_key_env),
+            aws_session_token=os.getenv(session_token_env),
         )
+
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ vertexai = [
 sql = [
   "sqlglot>=20.0.0",
 ]
+s3 = [
+  "boto3>=1.26.0",
+]
 example = [
   "python-dotenv>=1.0",
 ]

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -13,6 +13,7 @@ from aiobs.exporters import (
     CustomExporter,
     CompositeExporter,
     GCSExporter,
+    S3Exporter,
 )
 
 
@@ -437,6 +438,197 @@ class TestGCSExporter:
 
         # Should use the override, not the template
         mock_bucket.blob.assert_called_once_with("traces/custom-filename.json")
+
+
+# =============================================================================
+# S3Exporter Tests
+# =============================================================================
+
+class TestS3Exporter:
+    def test_initialization(self):
+        exporter = S3Exporter(
+            bucket="my-bucket",
+            prefix="traces/",
+            region="us-west-2",
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+        )
+        assert exporter.bucket == "my-bucket"
+        assert exporter.prefix == "traces/"
+        assert exporter.region == "us-west-2"
+        assert exporter.aws_access_key_id == "test-key"
+        assert exporter.aws_secret_access_key == "test-secret"
+        assert exporter.name == "s3"
+
+    def test_prefix_normalization(self):
+        # Without trailing slash
+        exp1 = S3Exporter(bucket="b", prefix="traces")
+        assert exp1.prefix == "traces/"
+
+        # With trailing slash
+        exp2 = S3Exporter(bucket="b", prefix="traces/")
+        assert exp2.prefix == "traces/"
+
+        # Empty prefix
+        exp3 = S3Exporter(bucket="b", prefix="")
+        assert exp3.prefix == ""
+
+    def test_filename_template(self):
+        exporter = S3Exporter(
+            bucket="b",
+            filename_template="{date}-{session_id}.json",
+        )
+        assert exporter.filename_template == "{date}-{session_id}.json"
+
+    def test_generate_filename(self):
+        exporter = S3Exporter(bucket="b", filename_template="{session_id}.json")
+        data = _create_mock_export(session_id="test-session-123")
+        filename = exporter._generate_filename(data)
+        assert filename == "test-session-123.json"
+
+    def test_generate_filename_empty_sessions(self):
+        exporter = S3Exporter(bucket="b", filename_template="{session_id}.json")
+        data = ObservabilityExport(
+            sessions=[],
+            events=[],
+            function_events=[],
+            generated_at=0.0,
+        )
+        filename = exporter._generate_filename(data)
+        assert filename == "unknown.json"
+
+    def test_export_success(self):
+        """Test successful export by injecting a mock client."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client.put_object = MagicMock()
+
+        exporter = S3Exporter(
+            bucket="test-bucket",
+            prefix="traces/",
+            region="us-east-1",
+        )
+        # Inject mock client directly
+        exporter._client = mock_client
+
+        data = _create_mock_export(session_id="sess-123")
+        result = exporter.export(data)
+
+        # Verify put_object was called with correct parameters
+        mock_client.put_object.assert_called_once()
+        call_kwargs = mock_client.put_object.call_args[1]
+        assert call_kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs["Key"] == "traces/sess-123.json"
+        assert call_kwargs["ContentType"] == "application/json"
+
+        # Verify result
+        assert result.success is True
+        assert result.destination == "s3://test-bucket/traces/sess-123.json"
+        assert result.metadata["bucket"] == "test-bucket"
+        assert result.metadata["key"] == "traces/sess-123.json"
+        assert result.metadata["region"] == "us-east-1"
+
+    def test_export_upload_content(self):
+        """Test that the exported JSON contains correct data."""
+        mock_client = MagicMock()
+        mock_client.put_object = MagicMock()
+
+        exporter = S3Exporter(bucket="test-bucket")
+        exporter._client = mock_client
+
+        data = _create_mock_export(session_id="test-sess")
+        exporter.export(data)
+
+        # Get the uploaded content
+        call_kwargs = mock_client.put_object.call_args[1]
+        uploaded_bytes = call_kwargs["Body"]
+        uploaded_data = json.loads(uploaded_bytes.decode("utf-8"))
+
+        assert len(uploaded_data["sessions"]) == 1
+        assert uploaded_data["sessions"][0]["id"] == "test-sess"
+        assert uploaded_data["version"] == 1
+
+    def test_export_missing_dependency(self):
+        exporter = S3Exporter(bucket="test-bucket")
+        exporter._client = None  # Ensure client needs to be created
+
+        # Patch the import to fail
+        with patch.dict("sys.modules", {"boto3": None}):
+            with pytest.raises(ExportError, match="boto3 is required"):
+                exporter._get_client()
+
+    def test_from_env_missing_bucket(self, monkeypatch):
+        monkeypatch.delenv("AIOBS_S3_BUCKET", raising=False)
+        with pytest.raises(ExportError, match="AIOBS_S3_BUCKET is required"):
+            S3Exporter.from_env()
+
+    def test_from_env_success(self, monkeypatch):
+        monkeypatch.setenv("AIOBS_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("AIOBS_S3_REGION", "us-west-2")
+        monkeypatch.setenv("AIOBS_S3_PREFIX", "env-prefix/")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-key")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "env-token")
+
+        exporter = S3Exporter.from_env()
+        assert exporter.bucket == "env-bucket"
+        assert exporter.region == "us-west-2"
+        assert exporter.prefix == "env-prefix/"
+        assert exporter.aws_access_key_id == "env-key"
+        assert exporter.aws_secret_access_key == "env-secret"
+        assert exporter.aws_session_token == "env-token"
+
+    def test_export_with_custom_metadata(self):
+        """Test that custom metadata is set on the object."""
+        mock_client = MagicMock()
+        mock_client.put_object = MagicMock()
+
+        exporter = S3Exporter(bucket="test-bucket")
+        exporter._client = mock_client
+
+        data = _create_mock_export()
+
+        custom_meta = {"environment": "production", "version": "1.0"}
+        exporter.export(data, metadata=custom_meta)
+
+        # Verify metadata was set on the object
+        call_kwargs = mock_client.put_object.call_args[1]
+        assert "Metadata" in call_kwargs
+        assert call_kwargs["Metadata"]["environment"] == "production"
+        assert call_kwargs["Metadata"]["version"] == "1.0"
+
+    def test_export_failure(self):
+        """Test that export failure raises ExportError."""
+        mock_client = MagicMock()
+        mock_client.put_object = MagicMock()
+        mock_client.put_object.side_effect = Exception("Upload failed")
+
+        exporter = S3Exporter(bucket="test-bucket")
+        exporter._client = mock_client
+
+        data = _create_mock_export()
+
+        with pytest.raises(ExportError, match="Failed to export to S3"):
+            exporter.export(data)
+
+    def test_export_with_filename_override(self):
+        """Test that filename kwarg overrides template."""
+        mock_client = MagicMock()
+        mock_client.put_object = MagicMock()
+
+        exporter = S3Exporter(
+            bucket="test-bucket",
+            prefix="traces/",
+            filename_template="{session_id}.json",
+        )
+        exporter._client = mock_client
+
+        data = _create_mock_export(session_id="original-session")
+        exporter.export(data, filename="custom-filename.json")
+
+        # Should use the override, not the template
+        call_kwargs = mock_client.put_object.call_args[1]
+        assert call_kwargs["Key"] == "traces/custom-filename.json"
 
 
 # =============================================================================


### PR DESCRIPTION
This PR adds S3Exporter to the aiobs.exporters package, allowing users to export observability data directly to Amazon S3 buckets.

Features:

- Export observability data to Amazon S3 buckets

- Support for AWS authentication (credentials, IAM roles, profiles)

- Configurable bucket, region, and prefix

- Filename templates with placeholders

- Custom metadata support

- from_env() class method for environment variable configuration

- Lazy import of boto3 (optional dependency)